### PR TITLE
fix: version of autoconf 2.69 -> 2.71

### DIFF
--- a/projects/ffmpeg/Dockerfile
+++ b/projects/ffmpeg/Dockerfile
@@ -15,7 +15,7 @@
 ################################################################################
 
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf libtool build-essential \
+RUN apt-get update && apt-get install -y make libtool build-essential \
 	libass-dev:i386 libfreetype6-dev:i386 \
 	libvdpau-dev:i386 libxcb1-dev:i386 libxcb-shm0-dev:i386 libdrm-dev:i386 \
 	texinfo libbz2-dev:i386 libbz2-1.0:i386 lib32z1 zlib1g:i386 zlib1g-dev:i386 yasm cmake mercurial wget \
@@ -25,6 +25,8 @@ RUN apt-get update && apt-get install -y make autoconf libtool build-essential \
 	pkg-config texinfo libbz2-dev zlib1g zlib1g-dev yasm cmake mercurial wget \
 	xutils-dev libpciaccess-dev nasm rsync libvpx-dev chrpath
 
+RUN curl -LO http://mirrors.edge.kernel.org/ubuntu/pool/main/a/autoconf/autoconf_2.71-2_all.deb && \
+    apt install ./autoconf_2.71-2_all.deb
 RUN curl -LO http://mirrors.kernel.org/ubuntu/pool/main/a/automake-1.16/automake_1.16.5-1.3_all.deb && \
     apt install ./automake_1.16.5-1.3_all.deb
 RUN git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg


### PR DESCRIPTION
currently build `ffmpeg` will get error

```
+ cd /src/libXext
+ ./autogen.sh
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal -I m4
configure.ac:3: error: Autoconf version 2.70 or higher is required
configure.ac:3: the top level
autom4te: /usr/bin/m4 failed with exit status: 63
aclocal: error: /usr/bin/autom4te failed with exit status: 63
autoreconf: aclocal failed with exit status: 63
ERROR:root:Building fuzzers failed.
```

To reproduce:
```
git clone https://github.com/google/oss-fuzz.git
cd oss-fuzz
python3  infra/helper.py build_fuzzers ffmpeg --sanitizer none
```